### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@
 ```
 ### 2.自定义Toast停留时间+到屏幕上端/下端距离(见如下方法)
 
-####1.显示至window(通过XHToast调用)
+#### 1.显示至window(通过XHToast调用)
 
 ```objc
 #pragma mark-中间显示
@@ -130,7 +130,7 @@
 
 ```
 
-####2.在view上显示(通过view调用)
+#### 2.在view上显示(通过view调用)
 
 ```objc
 #pragma mark-中间显示


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
